### PR TITLE
Fixed 'str' object has no attribute 'value' error in Python 2.7

### DIFF
--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -217,7 +217,7 @@ class SoundTouchDevice:
         play = '<ContentItem source="%s" type="uri" sourceAccount="%s" ' \
                'location="%s"><itemName>Select using API</itemName>' \
                '</ContentItem>' % (
-                   source.value, source_acc if source_acc else '', location)
+                   source, source_acc if source_acc else '', location)
         requests.post('http://' + self._host + ":" +
                       str(self._port) + action, play)
 
@@ -281,47 +281,47 @@ class SoundTouchDevice:
 
     def mute(self):
         """Mute/Un-mute volume."""
-        self._send_key(Key.MUTE.value)
+        self._send_key(Key.MUTE)
 
     def volume_up(self):
         """Volume up."""
-        self._send_key(Key.VOLUME_UP.value)
+        self._send_key(Key.VOLUME_UP)
 
     def volume_down(self):
         """Volume down."""
-        self._send_key(Key.VOLUME_DOWN.value)
+        self._send_key(Key.VOLUME_DOWN)
 
     def next_track(self):
         """Switch to next track."""
-        self._send_key(Key.NEXT_TRACK.value)
+        self._send_key(Key.NEXT_TRACK)
 
     def previous_track(self):
         """Switch to previous track."""
-        self._send_key(Key.PREV_TRACK.value)
+        self._send_key(Key.PREV_TRACK)
 
     def pause(self):
         """Pause."""
-        self._send_key(Key.PAUSE.value)
+        self._send_key(Key.PAUSE)
 
     def play(self):
         """Play."""
-        self._send_key(Key.PLAY.value)
+        self._send_key(Key.PLAY)
 
     def play_pause(self):
         """Toggle play status."""
-        self._send_key(Key.PLAY_PAUSE.value)
+        self._send_key(Key.PLAY_PAUSE)
 
     def repeat_off(self):
         """Turn off repeat."""
-        self._send_key(Key.REPEAT_OFF.value)
+        self._send_key(Key.REPEAT_OFF)
 
     def repeat_one(self):
         """Repeat one. Doesn't work."""
-        self._send_key(Key.REPEAT_ONE.value)
+        self._send_key(Key.REPEAT_ONE)
 
     def repeat_all(self):
         """Repeat all."""
-        self._send_key(Key.REPEAT_ALL.value)
+        self._send_key(Key.REPEAT_ALL)
 
     def shuffle(self, shuffle):
         """Shuffle on/off.
@@ -329,19 +329,19 @@ class SoundTouchDevice:
         :param shuffle: Boolean on/off
         """
         if shuffle:
-            self._send_key(Key.SHUFFLE_ON.value)
+            self._send_key(Key.SHUFFLE_ON)
         else:
-            self._send_key(Key.SHUFFLE_OFF.value)
+            self._send_key(Key.SHUFFLE_OFF)
 
     def power_on(self):
         """Power on device."""
         if self.status().source == STATE_STANDBY:
-            self._send_key(Key.POWER.value)
+            self._send_key(Key.POWER)
 
     def power_off(self):
         """Power off device."""
         if self.status().source != STATE_STANDBY:
-            self._send_key(Key.POWER.value)
+            self._send_key(Key.POWER)
 
 
 class Config:


### PR DESCRIPTION
Thank you for the acknowledgement! FYI, I am working on Python 2.7.
I upgraded the libsoundtouch library to the new 0.2.0 version, but I was getting the error as stated above. This is caused by the Enum types chosen (and is very strange that this error did not pop up before).
I removed the ".value" statement after calling upon the Enum values, which fixed the problem (hence this pull request).