### PR TITLE
Allows caller of play_media to specify type

### DIFF
--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -201,7 +201,7 @@ class SoundTouchDevice:
         requests.post('http://' + self._host + ":" +
                       str(self._port) + action, release)
 
-    def play_media(self, source, location, source_acc=None):
+    def play_media(self, source, location, source_acc=None, type="uri"):
         """
         Start music playback from a chosen source.
 
@@ -212,12 +212,15 @@ class SoundTouchDevice:
         For Spotify, this can be found by playing Spotify on the connected
         SoundTouch speaker, and calling:
         device.status().content_item.source_account
+        :param type: Type of the requested music. Typical values are: "uri",
+        "track", "album", "playlist". This can be found in
+        device.status().content_item.type
         """
         action = "/select"
-        play = '<ContentItem source="%s" type="uri" sourceAccount="%s" ' \
+        play = '<ContentItem source="%s" type="%s" sourceAccount="%s" ' \
                'location="%s"><itemName>Select using API</itemName>' \
                '</ContentItem>' % (
-                   source.value, source_acc if source_acc else '', location)
+                   source.value, type, source_acc if source_acc else '', location)
         requests.post('http://' + self._host + ":" +
                       str(self._port) + action, play)
 


### PR DESCRIPTION
Currently type is hardcoded to be "uri", which only works for streaming. In order to play local music library, type needs to be "track", "album", "playlist", etc.