### PR TITLE
Use enum-compat instead of enum34 directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 websocket-client
-enum34
+enum-compat
 zeroconf

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
     'requests>=2,<3',
-    'enum34>=1.1.6',
+    'enum-compat>=0.0.2',
     'websocket-client>=0.40.0',
     'zeroconf>=0.19.1'
 ]


### PR DESCRIPTION
Hi,

I'm getting an error in Home Assistant running python 3.6 that uses your library: `AttributeError: module 'enum' has no attribute 'IntFlag'`

It appears enum34 is not meant to be installed in Python versions 3.4+ 
so this fixes it.

Let me know what you think,