### PR TITLE
Add play_url method to play HTTP URL using DLNA

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Features
 -  shuffle on/off
 -  select preset (bookmark)
 -  playback selected music
+-  play HTTP URL (not HTTPS)
 -  Multi room (zones)
 -  Websocket notifications
 
@@ -107,6 +108,9 @@ Basic Usage
       'album:1',
       account_id,
       Type.ALBUM)
+
+   # Play an HTTP URL (not HTTPS)
+   device.play_url('http://fqdn/file.mp3')
 
    # Volume object
    # device.volume() will do an HTTP request.

--- a/libsoundtouch/templates/avt_transport_uri.xml
+++ b/libsoundtouch/templates/avt_transport_uri.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <s:Body>
+        <u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+            <InstanceID>0</InstanceID><CurrentURIMetaData></CurrentURIMetaData><CurrentURI>{0}</CurrentURI>
+        </u:SetAVTransportURI>
+    </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Add a new method to play an HTTP URL.

DLNA is used in order to ask the device to play an URL because the Soundtouch API doesn't support direct play.

Only HTTP protocol is supported, not HTTPS