### PR TITLE
Fix encoding issue with unicode-encoded device name

### DIFF
--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -132,7 +132,7 @@ class SoundTouchDevice:
     def __init_config(self):
         response = requests.get(
             "http://" + self._host + ":" + str(self._port) + "/info")
-        dom = minidom.parseString(response.text)
+        dom = minidom.parseString(response.content.decode('utf-8'))
         self._config = Config(dom)
 
     def start_notification(self):


### PR DESCRIPTION
My device is called "Küche". The current implementation could not correctly cope with it, neither locally in my win machine, nor on my docker-based home-assistant installation. The proposed PR fixes that on my local machine, but I'm not sure if this is a correct fix for all environments. So handle with care :)