### PR TITLE
Update utils.py

### DIFF
--- a/libsoundtouch/utils.py
+++ b/libsoundtouch/utils.py
@@ -59,6 +59,7 @@ class Source(Enum):
     LOCAL_MUSIC = "LOCAL_MUSIC"
     BLUETOOTH = "BLUETOOTH"
     INVALID_SOURCE = "INVALID_SOURCE"
+    TUNEIN = "TUNEIN"
 
 
 class Type(Enum):


### PR DESCRIPTION
Bose discontinued INTERNET_RADIO and moved everything radio-related to a new source called "TUNEIN". The library can't properly control what's to be played without this addition.