### PR TITLE
Add /sources

### DIFF
--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=too-many-public-methods,too-many-instance-attributes,
 # pylint: disable=useless-super-delegation,too-many-lines
-# pylint: disable=useless-object-inheritance
 
 import logging
 import os

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -99,6 +99,12 @@ class SoundTouchDevice:
                     self._presets.append(Preset(preset))
                 self.__run_listener(self._presets_updated_listeners,
                                     self._presets)
+            if action == "sourcesUpdated" and action_node.hasChildNodes():
+                self._sources = []
+                for sourceItem in _get_dom_elements(dom, "sourceItem"):
+                    self._sources.append(SourceItem(sourceItem))
+                self.__run_listener(self._sources_updated_listeners,
+                                    self._sources)
             if action == "zoneUpdated":
                 self.__run_listener(self._zone_status_updated_listeners,
                                     self.zone_status(True))
@@ -124,10 +130,12 @@ class SoundTouchDevice:
         self._volume = None
         self._zone_status = None
         self._presets = None
+        self._sources = None
         self._ws_client = None
         self._volume_updated_listeners = []
         self._status_updated_listeners = []
         self._presets_updated_listeners = []
+        self._sources_updated_listeners = []
         self._zone_status_updated_listeners = []
         self._device_info_updated_listeners = []
         self._snapshot = None
@@ -159,6 +167,10 @@ class SoundTouchDevice:
     def add_presets_listener(self, listener):
         """Add a new presets updated listener."""
         self._presets_updated_listeners.append(listener)
+        
+    def add_sources_listener(self, listener):
+        """Add a new sources updated listener."""
+        self._sources_updated_listeners.append(listener)
 
     def add_zone_status_listener(self, listener):
         """Add a new zone status updated listener."""
@@ -182,6 +194,11 @@ class SoundTouchDevice:
         """Remove a new presets updated listener."""
         if listener in self._presets_updated_listeners:
             self._presets_updated_listeners.remove(listener)
+            
+    def remove_sources_listener(self, listener):
+        """Remove a new sources updated listener."""
+        if listener in self._sources_updated_listeners:
+            self._sources_updated_listeners.remove(listener)
 
     def remove_zone_status_listener(self, listener):
         """Remove a new zone status updated listener."""
@@ -204,6 +221,10 @@ class SoundTouchDevice:
     def clear_presets_listeners(self):
         """Clear presets updated listeners."""
         del self._presets_updated_listeners[:]
+        
+    def clear_sources_listeners(self):
+        """Clear sources updated listeners."""
+        del self._sources_updated_listeners[:]
 
     def clear_zone_status_listeners(self):
         """Clear zone status updated listeners."""
@@ -227,6 +248,11 @@ class SoundTouchDevice:
     def presets_updated_listeners(self):
         """Return Presets Updated listeners."""
         return self._presets_updated_listeners
+        
+    @property
+    def sources_updated_listeners(self):
+        """Return Sources Updated listeners."""
+        return self._sources_updated_listeners
 
     @property
     def zone_status_updated_listeners(self):
@@ -262,6 +288,16 @@ class SoundTouchDevice:
         self._presets = []
         for preset in _get_dom_elements(dom, "preset"):
             self._presets.append(Preset(preset))
+            
+    def refresh_sources(self):
+        """Refersh sources."""
+        response = requests.get(
+            "http://" + self._host + ":" + str(self._port) + "/sources")
+        response.encoding = 'UTF-8'
+        dom = minidom.parseString(response.text.encode('utf-8'))
+        self._sources = []
+        for sourceItem in _get_dom_elements(dom, "sourceItem"):
+            self._sources.append(SourceItem(sourceItem))
 
     def refresh_zone_status(self):
         """Refresh Zone Status."""
@@ -508,6 +544,15 @@ class SoundTouchDevice:
         if self._presets is None or refresh:
             self.refresh_presets()
         return self._presets
+        
+    def sources(self, refresh=True):
+        """Sources.
+
+        :param refresh: Force refresh, else return old data.
+        """
+        if self._sources is None or refresh:
+            self.refresh_sources()
+        return self._sources
 
     def set_volume(self, level):
         """Set volume level: from 0 to 100."""
@@ -938,6 +983,48 @@ class ContentItem:
                   self.is_presetable]
         formated_fields = [str(f) for f in fields]
         return 'ContentItem(' + ",".join(formated_fields) + ')'
+
+
+class SourceItem:
+    """Source item."""
+
+    def __init__(self, xml_dom):
+        """Create a new source item.
+
+        :param xml_dom: Source item XML DOM
+        """
+        self._source = _get_dom_attribute(xml_dom, "source")
+        self._source_account = _get_dom_attribute(xml_dom, "sourceAccount")
+        self._status = _get_dom_attribute(xml_dom, "status")
+        self._is_local = _get_dom_attribute(xml_dom,
+                                             "isLocal") == 'true'
+        self._multi_room_allowed = _get_dom_attribute(xml_dom,
+                                             "multiroomallowed") == 'true'
+
+    @property
+    def source(self):
+        """Source."""
+        return self._source
+
+    @property
+    def source_account(self):
+        """Source account."""
+        return self._source_account
+        
+    @property
+    def status(self):
+        """Status."""
+        return self._status
+
+    @property
+    def is_local(self):
+        """Return true if local."""
+        return self._is_local
+
+    @property
+    def multi_room_allowed(self):
+        """Return true if multi room allowed."""
+        return self._multi_room_allowed
 
 
 class Volume:

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -287,7 +287,7 @@ class SoundTouchDevice:
         self._presets = []
         for preset in _get_dom_elements(dom, "preset"):
             self._presets.append(Preset(preset))
-            
+
     def refresh_sources(self):
         """Refersh sources."""
         response = requests.get(
@@ -997,7 +997,8 @@ class SourceItem:
         self._status = _get_dom_attribute(xml_dom, "status")
         self._is_local = _get_dom_attribute(xml_dom, "isLocal") == 'true'
         self._multi_room_allowed = _get_dom_attribute(xml_dom,
-                                                      "multiroomallowed") == 'true'
+                                                      "multiroomallowed") \
+                                                      == 'true'
 
     @property
     def source(self):

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -996,7 +996,7 @@ class SourceItem:
         self._source_account = _get_dom_attribute(xml_dom, "sourceAccount")
         self._status = _get_dom_attribute(xml_dom, "status")
         self._is_local = _get_dom_attribute(xml_dom, "isLocal") == 'true'
-        self._multi_room_allowed = _get_dom_attribute(xml_dom, \
+        self._multi_room_allowed = _get_dom_attribute(xml_dom,
                                                       "multiroomallowed") == 'true'
 
     @property

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -34,8 +34,7 @@ def _get_dom_element_attribute(xml_dom, element, attribute,
         if attribute in element.attributes.keys():
             return element.attributes[attribute].value
         return None
-    else:
-        return default_value
+    return default_value
 
 
 def _get_dom_elements(xml_dom, element):
@@ -101,8 +100,8 @@ class SoundTouchDevice:
                                     self._presets)
             if action == "sourcesUpdated" and action_node.hasChildNodes():
                 self._sources = []
-                for sourceItem in _get_dom_elements(dom, "sourceItem"):
-                    self._sources.append(SourceItem(sourceItem))
+                for source_item in _get_dom_elements(dom, "sourceItem"):
+                    self._sources.append(SourceItem(source_item))
                 self.__run_listener(self._sources_updated_listeners,
                                     self._sources)
             if action == "zoneUpdated":
@@ -167,7 +166,7 @@ class SoundTouchDevice:
     def add_presets_listener(self, listener):
         """Add a new presets updated listener."""
         self._presets_updated_listeners.append(listener)
-        
+
     def add_sources_listener(self, listener):
         """Add a new sources updated listener."""
         self._sources_updated_listeners.append(listener)
@@ -194,7 +193,7 @@ class SoundTouchDevice:
         """Remove a new presets updated listener."""
         if listener in self._presets_updated_listeners:
             self._presets_updated_listeners.remove(listener)
-            
+
     def remove_sources_listener(self, listener):
         """Remove a new sources updated listener."""
         if listener in self._sources_updated_listeners:
@@ -221,7 +220,7 @@ class SoundTouchDevice:
     def clear_presets_listeners(self):
         """Clear presets updated listeners."""
         del self._presets_updated_listeners[:]
-        
+
     def clear_sources_listeners(self):
         """Clear sources updated listeners."""
         del self._sources_updated_listeners[:]
@@ -248,7 +247,7 @@ class SoundTouchDevice:
     def presets_updated_listeners(self):
         """Return Presets Updated listeners."""
         return self._presets_updated_listeners
-        
+
     @property
     def sources_updated_listeners(self):
         """Return Sources Updated listeners."""
@@ -296,8 +295,8 @@ class SoundTouchDevice:
         response.encoding = 'UTF-8'
         dom = minidom.parseString(response.text.encode('utf-8'))
         self._sources = []
-        for sourceItem in _get_dom_elements(dom, "sourceItem"):
-            self._sources.append(SourceItem(sourceItem))
+        for source_item in _get_dom_elements(dom, "sourceItem"):
+            self._sources.append(SourceItem(source_item))
 
     def refresh_zone_status(self):
         """Refresh Zone Status."""
@@ -544,7 +543,7 @@ class SoundTouchDevice:
         if self._presets is None or refresh:
             self.refresh_presets()
         return self._presets
-        
+
     def sources(self, refresh=True):
         """Sources.
 
@@ -996,10 +995,9 @@ class SourceItem:
         self._source = _get_dom_attribute(xml_dom, "source")
         self._source_account = _get_dom_attribute(xml_dom, "sourceAccount")
         self._status = _get_dom_attribute(xml_dom, "status")
-        self._is_local = _get_dom_attribute(xml_dom,
-                                             "isLocal") == 'true'
-        self._multi_room_allowed = _get_dom_attribute(xml_dom,
-                                             "multiroomallowed") == 'true'
+        self._is_local = _get_dom_attribute(xml_dom, "isLocal") == 'true'
+        self._multi_room_allowed = _get_dom_attribute(xml_dom, \
+                                                      "multiroomallowed") == 'true'
 
     @property
     def source(self):
@@ -1010,7 +1008,7 @@ class SourceItem:
     def source_account(self):
         """Source account."""
         return self._source_account
-        
+
     @property
     def status(self):
         """Status."""

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -996,9 +996,8 @@ class SourceItem:
         self._source_account = _get_dom_attribute(xml_dom, "sourceAccount")
         self._status = _get_dom_attribute(xml_dom, "status")
         self._is_local = _get_dom_attribute(xml_dom, "isLocal") == 'true'
-        self._multi_room_allowed = _get_dom_attribute(xml_dom,
-                                                      "multiroomallowed") \
-                                                      == 'true'
+        self._multi_room_allowed = \
+            _get_dom_attribute(xml_dom, "multiroomallowed") == 'true'
 
     @property
     def source(self):

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -349,7 +349,7 @@ class SoundTouchDevice:
         self.select_content_item(Source.BLUETOOTH)
 
     def _create_zone(self, slaves):
-        if len(slaves) <= 0:
+        if not slaves:
             raise NoSlavesException()
         request_body = '<zone master="%s" senderIPAddress="%s">' % (
             self.config.device_id, self.config.device_ip
@@ -361,7 +361,7 @@ class SoundTouchDevice:
         return request_body
 
     def _get_zone_request_body(self, slaves):
-        if len(slaves) <= 0:
+        if not slaves:
             raise NoSlavesException()
         request_body = '<zone master="%s">' % self.config.device_id
         for slave in slaves:
@@ -415,7 +415,7 @@ class SoundTouchDevice:
         if self.zone_status() is None:
             raise NoExistingZoneException()
         request_body = self._get_zone_request_body(slaves)
-        _LOGGER.info("Removing slaves from multi-room zone with master " +
+        _LOGGER.info("Removing slaves from multi-room zone with master "
                      "device %s", self.config.name)
         requests.post(
             "http://" + self.host + ":" + str(

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -68,7 +68,7 @@ class WebSocketThread(Thread):
         self._ws.run_forever()
 
 
-class SoundTouchDevice:
+class SoundTouchDevice(object):
     """Bose SoundTouch Device."""
 
     @staticmethod

--- a/libsoundtouch/device.py
+++ b/libsoundtouch/device.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-public-methods,too-many-instance-attributes,
 # pylint: disable=useless-super-delegation,too-many-lines
+# pylint: disable=useless-object-inheritance
 
 import logging
 import os
@@ -68,7 +69,7 @@ class WebSocketThread(Thread):
         self._ws.run_forever()
 
 
-class SoundTouchDevice(object):
+class SoundTouchDevice:
     """Bose SoundTouch Device."""
 
     @staticmethod

--- a/libsoundtouch/utils.py
+++ b/libsoundtouch/utils.py
@@ -75,7 +75,7 @@ class Type(Enum):
     PLAYLIST = "playlist"
 
 
-class SoundtouchDeviceListener(object):
+class SoundtouchDeviceListener:
     """Message listener."""
 
     def __init__(self, add_device_function):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ PROJECT_CLASSIFIERS = [
 
 setup(
     name="libsoundtouch",
-    version="0.8.0",
+    version="0.8.1",
     license="Apache License 2.0",
     url="http://libsoundtouch.readthedocs.io",
     download_url="https://github.com/CharlesBlonde/libsoundtouch",

--- a/tox.ini
+++ b/tox.ini
@@ -58,4 +58,4 @@ basepython = python3
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --silent-imports libsoundtouch
+         mypy --ignore-missing-imports --follow-imports=skip libsoundtouch


### PR DESCRIPTION
Hi folks,

This pull request adds the ability to query SoundTouch devices for a list of available sources via GET /sources API lookup. Info on that is here:
https://developer.bose.com/guides/bose-soundtouch-api/bose-soundtouch-api-reference -> (GET) sources

Since not all SoundTouch devices support AUX, this addition allows us to use /sources to build a list of sources available per device and to to check for source status (READY/UNAVAILABLE).

If there's interest in taking this PR, I can add unit tests.

If and once approved, I'll send a corresponding pull-request for HomeAssistant to update to the latest libsoundtouch version to add source switching support for AUX and Bluetooth.

Feedback is welcome.

Thank you for your time!